### PR TITLE
Fix: cannot find derive macro Topic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vehicle-signals = "0.2"
+vehicle-signals = "0.2.1"
 cyclonedds-rs = "0.4.1"
 async-std = "1.9.0"
 futures = "0.3"


### PR DESCRIPTION
Signed-off-by: Fanjun Kong <fanjun.kong@linux.dev>

same error with previous here:
https://github.com/sjames/demo-vehicle-speed-publisher/pull/1

Thanks